### PR TITLE
Make json reader more tolerant of number values in JSON payloads

### DIFF
--- a/node/json_rdr.go
+++ b/node/json_rdr.go
@@ -51,32 +51,64 @@ func leafOrLeafListJsonReader(m meta.HasDataType, data interface{}) (v *Value, e
 	v = &Value{Type: m.GetDataType()}
 	switch v.Type.Format() {
 	case meta.FMT_INT64:
-		v.Int64 = int64(data.(float64))
+		valF64, err := asFloat64(data)
+		if err != nil {
+			return nil, err
+		}
+		v.Int64 = int64(valF64)
 	case meta.FMT_UINT64:
-		v.UInt64 = uint64(data.(float64))
+		valF64, err := asFloat64(data)
+		if err != nil {
+			return nil, err
+		}
+		v.UInt64 = uint64(valF64)
 	case meta.FMT_INT64_LIST:
 		a := data.([]interface{})
 		v.Int64list = make([]int64, len(a))
 		for i, f := range a {
-			v.Int64list[i] = int64(f.(float64))
+			valF64, err := asFloat64(f)
+			if err != nil {
+				return nil, err
+			}
+			v.Int64list[i] = int64(valF64)
 		}
 	case meta.FMT_INT32:
-		v.Int = int(data.(float64))
+		valF64, err := asFloat64(data)
+		if err != nil {
+			return nil, err
+		}
+		v.Int = int(valF64)
 	case meta.FMT_UINT32:
-		v.UInt = uint(data.(float64))
+		valF64, err := asFloat64(data)
+		if err != nil {
+			return nil, err
+		}
+		v.UInt = uint(valF64)
 	case meta.FMT_INT32_LIST:
 		a := data.([]interface{})
 		v.Intlist = make([]int, len(a))
 		for i, f := range a {
-			v.Intlist[i] = int(f.(float64))
+			valF64, err := asFloat64(f)
+			if err != nil {
+				return nil, err
+			}
+			v.Intlist[i] = int(valF64)
 		}
 	case meta.FMT_DECIMAL64:
-		v.Float = data.(float64)
+		valF64, err := asFloat64(data)
+		if err != nil {
+			return nil, err
+		}
+		v.Float = valF64
 	case meta.FMT_DECIMAL64_LIST:
 		a := data.([]interface{})
 		v.Floatlist = make([]float64, len(a))
-		for i, data := range a {
-			v.Floatlist[i] = data.(float64)
+		for i, f := range a {
+			valF64, err := asFloat64(f)
+			if err != nil {
+				return nil, err
+			}
+			v.Floatlist[i] = valF64
 		}
 	case meta.FMT_STRING:
 		switch vdata := data.(type) {
@@ -133,6 +165,25 @@ func leafOrLeafListJsonReader(m meta.HasDataType, data interface{}) (v *Value, e
 		return nil, errors.New(msg)
 	}
 	return
+}
+
+func asFloat64(data interface{}) (val float64, err error) {
+	var valF64 float64
+	valF64, ok := data.(float64)
+	if !ok {
+		valStr, ok := data.(string)
+		if !ok {
+			msg := fmt.Sprint("JSON reading value could not parse %v as int64", data)
+			return 0.0, errors.New(msg)
+		}
+		valF64, err = strconv.ParseFloat(valStr, 64)
+		if err != nil {
+			msg := fmt.Sprint("JSON reading value could not parse %v as int64: %s", data, err.Error())
+			return 0.0, errors.New(msg)
+		}
+	}
+
+	return valF64, nil
 }
 
 func asStringArray(data []interface{}) []string {

--- a/node/json_rdr_test.go
+++ b/node/json_rdr_test.go
@@ -46,7 +46,7 @@ module json-test {
 		sel := NewBrowserSource(module, rdr.Node).Root()
 		found := sel.Find(test)
 		if found.LastErr != nil {
-			t.Error("failed to transmit json", err)
+			t.Error("failed to transmit json", found.LastErr)
 		} else if found.IsNil() {
 			t.Error(test, "- Target not found, state nil")
 		} else {
@@ -54,6 +54,97 @@ module json-test {
 			if actual != "json-test/"+test {
 				t.Error("json-test/"+test, "!=", actual)
 			}
+		}
+	}
+}
+
+func TestNumberParse(t *testing.T) {
+	moduleStr := `
+module json-test {
+	prefix "t";
+	namespace "t";
+	revision 0;
+	container data {
+		leaf id {
+			type int32;
+		}
+		leaf idstr {
+			type int32;
+		}
+		leaf idstrwrong {
+			type int32;
+		}
+		leaf-list readings{
+			type decimal64;
+		}
+	}
+}
+	`
+	module, err := yang.LoadModuleCustomImport(moduleStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	json := `{ "data": {
+			"id": 4,
+			"idstr": "4",
+			"idstrwrong": "4s",
+			"readings": [
+				"3.555454",
+				"45.04545",
+				324545.04
+			]
+		}
+	}`
+
+	//test get id
+	rdr := NewJsonReader(strings.NewReader(json))
+	sel := NewBrowserSource(module, rdr.Node).Root().Find("data")
+	found, err := sel.Get("id")
+	if err != nil {
+		t.Error("failed to transmit json", err)
+	} else if found == nil {
+		t.Error("data/id - Target not found, state nil")
+	} else {
+		if 4 != found.(int) {
+			t.Error(found.(int), "!=", 4)
+		}
+	}
+
+	//test get idstr
+	rdr = NewJsonReader(strings.NewReader(json))
+	sel = NewBrowserSource(module, rdr.Node).Root().Find("data")
+	found, err = sel.Get("idstr")
+	if err != nil {
+		t.Error("failed to transmit json", err)
+	} else if found == nil {
+		t.Error("data/idstr - Target not found, state nil")
+	} else {
+		if 4 != found.(int) {
+			t.Error(found.(int), "!=", 4)
+		}
+	}
+
+	//test idstrwrong fail
+	rdr = NewJsonReader(strings.NewReader(json))
+	sel = NewBrowserSource(module, rdr.Node).Root().Find("data")
+	found, err = sel.Get("idstrwrong")
+	if err == nil {
+		t.Error("Failed to throw error on invalid input")
+	}
+
+	rdr = NewJsonReader(strings.NewReader(json))
+	sel = NewBrowserSource(module, rdr.Node).Root().Find("data")
+	found, err = sel.Get("readings")
+	if err != nil {
+		t.Error("failed to transmit json", err)
+	} else if found == nil {
+		t.Error("data/readings - Target not found, state nil")
+	} else {
+		expected := []float64{3.555454, 45.04545, 324545.04}
+		readings := found.([]float64)
+
+		if expected[0] != readings[0] || expected[1] != readings[1] || expected[2] != readings[2] {
+			t.Error(found.([]int), "!=", expected)
 		}
 	}
 }


### PR DESCRIPTION
It should be possible to get value even if numeric value is represented as string
Error should be trown only if string value can't be parsed as numeric value