### PR TITLE
Improvereadonlyaccess

### DIFF
--- a/nodeutil/reflect.go
+++ b/nodeutil/reflect.go
@@ -235,6 +235,14 @@ func (self valSorter) Less(i, j int) bool {
 	case reflect.Int:
 		return self[i].Int() < self[j].Int()
 	}
+	if i1, ok := self[i].Interface().(fmt.Stringer); ok {
+		i2 := self[j].Interface().(fmt.Stringer)
+		return strings.Compare(i1.String(), i2.String()) < 0
+	}
+	if i1, ok := self[i].Interface().(fmt.Stringer); ok {
+		i2 := self[j].Interface().(fmt.Stringer)
+		return strings.Compare(i1.String(), i2.String()) < 0
+	}
 	panic("not supported")
 }
 


### PR DESCRIPTION
More work on improved read access to existing datastructures by allowing any fmt.Stringer implementation as a map key and allowing to access map struct values that are not pointers.

I am bit unsure if the change in ReadField() and ReadFieldWithFieldName() is okay, maybe its better to add two new ReadFieldElem() and ReadFieldElemWithFieldName() ?