### PR TITLE
Extend nodeutil/reflect.go by using custom code for reading/writing per value type

### DIFF
--- a/testdata/bird.go
+++ b/testdata/bird.go
@@ -6,6 +6,7 @@ import (
 	"github.com/freeconf/yang/nodeutil"
 	"github.com/freeconf/yang/parser"
 	"github.com/freeconf/yang/source"
+	"net/netip"
 )
 
 type Bird struct {
@@ -16,6 +17,17 @@ type Bird struct {
 
 type Species struct {
 	Name  string
+	Class string
+}
+
+type IPBird struct {
+	Name     netip.Addr
+	Wingspan int
+	Species  *IPSpecies
+}
+
+type IPSpecies struct {
+	Name  netip.Addr
 	Class string
 }
 


### PR DESCRIPTION
Add option for custom (un)marshaller to reflect
Allow objects with fmt.Stringer to be used for read access
Allow read access to map values with references instead of pointers
Add testcases for new options