### PR TITLE
Use json tags for yang-serialization naming and allow derived types in stringlists

### DIFF
--- a/nodeutil/reflect.go
+++ b/nodeutil/reflect.go
@@ -515,12 +515,6 @@ func (self Reflect) WriteFieldWithFieldName(fieldName string, m meta.Leafable, p
 	}
 
 	fieldVal := elemVal.FieldByName(fieldName)
-	if !fieldVal.IsValid() {
-		panic(fmt.Sprintf("Invalid property \"%s\" on %s", fieldName, elemVal.Type()))
-	}
-	if v == nil {
-		panic(fmt.Sprintf("No value given to set %s", m.Ident()))
-	}
 
 	for _, f := range self.OnField {
 		if f.When(m, fieldName, elemVal, fieldVal) {
@@ -528,6 +522,13 @@ func (self Reflect) WriteFieldWithFieldName(fieldName string, m meta.Leafable, p
 				return f.OnWrite(m, fieldName, elemVal, fieldVal, v)
 			}
 		}
+	}
+
+	if !fieldVal.IsValid() {
+		panic(fmt.Sprintf("Invalid property \"%s\" on %s", fieldName, elemVal.Type()))
+	}
+	if v == nil {
+		panic(fmt.Sprintf("No value given to set %s", m.Ident()))
 	}
 
 	switch v.Format() {
@@ -584,9 +585,6 @@ func (self Reflect) ReadFieldWithFieldName(fieldName string, m meta.Leafable, pt
 	}
 
 	fieldVal := elemVal.FieldByName(fieldName)
-	if !fieldVal.IsValid() {
-		panic(fmt.Sprintf("Field not found: %s on %v", m.Ident(), ptrVal))
-	}
 
 	// check for custom handlers
 	for _, f := range self.OnField {
@@ -595,6 +593,10 @@ func (self Reflect) ReadFieldWithFieldName(fieldName string, m meta.Leafable, pt
 				return f.OnRead(m, fieldName, elemVal, fieldVal)
 			}
 		}
+	}
+
+	if !fieldVal.IsValid() {
+		panic(fmt.Sprintf("Field not found: %s on %v", m.Ident(), ptrVal))
 	}
 
 	// convert arrays to slices so casts work. this should not make a copy

--- a/nodeutil/reflect.go
+++ b/nodeutil/reflect.go
@@ -40,14 +40,17 @@ type Reflect struct {
 type ReflectField struct {
 
 	// Select when a field handling is used
+	// This might be called with an invalid fieldElem, so if it depends on this parameters it has to check.
 	When ReflectFieldSelector
 
 	// Called just after reading the value using reflection to convert value
 	// to freeconf value type.  Null means use default conversion
+	// This might be called with an invalid fieldElem, so if it depends on this parameters it has to check.
 	OnRead ReflectOnRead
 
 	// Called just before setting the value using reflection to convert value
 	// to native type.  Null means use default conversion
+	// This might be called with an invalid fieldElem, so if it depends on this parameters it has to check.
 	OnWrite ReflectOnWrite
 }
 

--- a/nodeutil/reflect.go
+++ b/nodeutil/reflect.go
@@ -658,7 +658,7 @@ func GetFieldName(parent reflect.Value, in string) string {
 
 	for i := 0; i < parent.Type().NumField(); i++ {
 		f := parent.Type().Field(i)
-		if tag, ok := f.Tag.Lookup("json"); ok {
+		if tag, ok := f.Tag.Lookup("yang"); ok {
 			name, _, _ := strings.Cut(tag, ",")
 
 			if name == in {

--- a/nodeutil/reflect_test.go
+++ b/nodeutil/reflect_test.go
@@ -39,7 +39,7 @@ func TestMetaNameToFieldNameExt(t *testing.T) {
 	var actual string
 
 	data := struct {
-		Renamed    string `json:"whatever"`
+		Renamed    string `yang:"whatever"`
 		Notrenamed string
 	}{}
 

--- a/nodeutil/reflect_test.go
+++ b/nodeutil/reflect_test.go
@@ -35,6 +35,31 @@ func TestMetaNameToFieldName(t *testing.T) {
 	}
 }
 
+func TestMetaNameToFieldNameExt(t *testing.T) {
+	var actual string
+
+	data := struct {
+		Renamed    string `json:"whatever"`
+		Notrenamed string
+	}{}
+
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{in: "Renamed", out: "Renamed"},
+		{in: "renamed", out: "Renamed"},
+		{in: "whatever", out: "Renamed"},
+		{in: "Notrenamed", out: "Notrenamed"},
+		{in: "notrenamed", out: "Notrenamed"},
+	}
+	for _, test := range tests {
+		if actual = nodeutil.MetaNameToFieldNameExt(reflect.ValueOf(data), test.in); actual != test.out {
+			t.Errorf("%v should be %v, got %v", test.in, test.out, actual)
+		}
+	}
+}
+
 var m1 = `module m {
 	revision 0;
 

--- a/nodeutil/reflect_test.go
+++ b/nodeutil/reflect_test.go
@@ -54,7 +54,7 @@ func TestMetaNameToFieldNameExt(t *testing.T) {
 		{in: "notrenamed", out: "Notrenamed"},
 	}
 	for _, test := range tests {
-		if actual = nodeutil.MetaNameToFieldNameExt(reflect.ValueOf(data), test.in); actual != test.out {
+		if actual = nodeutil.GetFieldName(reflect.ValueOf(data), test.in); actual != test.out {
 			t.Errorf("%v should be %v, got %v", test.in, test.out, actual)
 		}
 	}

--- a/val/conv.go
+++ b/val/conv.go
@@ -902,5 +902,24 @@ func toStringList(val interface{}) ([]string, error) {
 		}
 		return l, err
 	}
+
+	// handle types that are variants of interface, string of float64
+	rv := reflect.ValueOf(val)
+	if !rv.IsValid() || rv.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("cannot coerse '%T' to []string", val)
+	}
+
+	switch rv.Type().Elem().Kind() {
+	case reflect.Interface, reflect.String, reflect.Float64:
+		l := make([]string, rv.Len())
+		for i := range l {
+			s, err := toString(rv.Index(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+			l[i] = s
+		}
+		return l, nil
+	}
 	return nil, fmt.Errorf("cannot coerse '%T' to []string", val)
 }

--- a/val/conv.go
+++ b/val/conv.go
@@ -869,57 +869,29 @@ func toBool(val interface{}) (bool, error) {
 }
 
 func toString(val interface{}) (string, error) {
-	switch x := val.(type) {
-	case float64:
+	rv := reflect.ValueOf(val)
+	if rv.Kind() == reflect.Float64 {
 		// wrong format, truncating decimals as most likely mistake but
 		// will not please everyone.  Get input in correct format by placing
 		// quotes around data.
-		return strconv.FormatFloat(x, 'f', 0, 64), nil
+		return strconv.FormatFloat(rv.Float(), 'f', 0, 64), nil
 	}
 	return fmt.Sprintf("%v", val), nil
 }
 
 func toStringList(val interface{}) ([]string, error) {
-	switch x := val.(type) {
-	case []string:
-		return x, nil
-	case []float64:
-		l := make([]string, len(x))
-		var err error
-		for i := 0; i < len(x); i++ {
-			if l[i], err = toString(x[i]); err != nil {
-				return nil, err
-			}
-		}
-		return l, err
-	case []interface{}:
-		l := make([]string, len(x))
-		var err error
-		for i := 0; i < len(x); i++ {
-			if l[i], err = toString(x[i]); err != nil {
-				return nil, err
-			}
-		}
-		return l, err
-	}
-
-	// handle types that are variants of interface, string of float64
 	rv := reflect.ValueOf(val)
 	if !rv.IsValid() || rv.Kind() != reflect.Slice {
 		return nil, fmt.Errorf("cannot coerse '%T' to []string", val)
 	}
 
-	switch rv.Type().Elem().Kind() {
-	case reflect.Interface, reflect.String, reflect.Float64:
-		l := make([]string, rv.Len())
-		for i := range l {
-			s, err := toString(rv.Index(i).Interface())
-			if err != nil {
-				return nil, err
-			}
-			l[i] = s
+	l := make([]string, rv.Len())
+	var err error
+	for i := 0; i < rv.Len(); i++ {
+		x := rv.Index(i).Interface()
+		if l[i], err = toString(x); err != nil {
+			return nil, err
 		}
-		return l, nil
 	}
-	return nil, fmt.Errorf("cannot coerse '%T' to []string", val)
+	return l, nil
 }

--- a/val/conv_test.go
+++ b/val/conv_test.go
@@ -9,6 +9,8 @@ import (
 func Test_Conv(t *testing.T) {
 	type CustomUint32 uint32
 	type CustomInt32 int32
+	type CustomString string
+	type CustomFloat64 float64
 	tests := []struct {
 		F       Format
 		In      interface{}
@@ -174,6 +176,46 @@ func Test_Conv(t *testing.T) {
 			F:   FmtDecimal64List,
 			In:  []interface{}{"99", 98},
 			Out: []float64{99, 98},
+		},
+		{
+			F:   FmtString,
+			In:  "a",
+			Out: "a",
+		},
+		{
+			F:   FmtString,
+			In:  1.4,
+			Out: "1",
+		},
+		{
+			F:   FmtString,
+			In:  CustomString("a"),
+			Out: "a",
+		},
+		{
+			F:   FmtStringList,
+			In:  []string{"a", "b"},
+			Out: []string{"a", "b"},
+		},
+		{
+			F:   FmtStringList,
+			In:  []float64{1.4, 1.5},
+			Out: []string{"1", "2"},
+		},
+		{
+			F:   FmtStringList,
+			In:  []CustomString{"a", "b"},
+			Out: []string{"a", "b"},
+		},
+		{
+			F:   FmtStringList,
+			In:  []CustomFloat64{1.2, 1.3},
+			Out: []string{"1", "1"},
+		},
+		{
+			F:   FmtStringList,
+			In:  []interface{}{"a", "b"},
+			Out: []string{"a", "b"},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Instead of just guessing (by shortening/camelcase) the go fieldname of a struct, look for json tags that define a fitting name.

Allow types derived from string/float64 to be used in Stringlists, e.g.:
`type Specialtype float64`