### PR TITLE
Use reflect api type conversion to assign value in nodeutil

### DIFF
--- a/nodeutil/reflect.go
+++ b/nodeutil/reflect.go
@@ -564,7 +564,7 @@ func (self Reflect) WriteFieldWithFieldName(fieldName string, m meta.Leafable, p
 			fieldVal.Set(reflect.ValueOf(el.Labels()))
 		}
 	default:
-		fieldVal.Set(reflect.ValueOf(v.Value()))
+		fieldVal.Set(reflect.ValueOf(v.Value()).Convert(fieldVal.Type()))
 	}
 	return nil
 }

--- a/nodeutil/reflect_test.go
+++ b/nodeutil/reflect_test.go
@@ -115,6 +115,18 @@ func TestReflect2Write(t *testing.T) {
 		write(nodeutil.ReflectChild(bird), m1, `{"name":"robin"}`)
 		fc.AssertEqual(t, "robin", bird.Name)
 	}
+	// structs with derived type
+	{
+		type SpecialName string
+		type SpecialBird struct {
+			Name     SpecialName
+			Wingspan int
+			Species  *testdata.Species
+		}
+		bird := &SpecialBird{}
+		write(nodeutil.ReflectChild(bird), m1, `{"name":"robin"}`)
+		fc.AssertEqual(t, SpecialName("robin"), bird.Name)
+	}
 	// struct + field conversions on write
 	{
 		ipBird := &testdata.IPBird{}

--- a/nodeutil/reflect_test.go
+++ b/nodeutil/reflect_test.go
@@ -96,6 +96,15 @@ var m2 = `module m {
 }
 `
 
+var m3 = `module m {
+	revision 0;
+
+	leaf-list names {
+		type string;
+	}
+}
+`
+
 func TestReflect2Write(t *testing.T) {
 	var b *node.Browser
 	write := func(n node.Node, mstr string, data string) {
@@ -108,6 +117,21 @@ func TestReflect2Write(t *testing.T) {
 		if err = sel.UpsertFrom(nodeutil.ReadJSON(data)).LastErr; err != nil {
 			t.Error(err)
 		}
+	}
+	// leaflist with derived type
+	{
+		type SpecialName string
+		type Birds struct {
+			Names []SpecialName
+		}
+
+		birds := &Birds{
+			Names: []SpecialName{},
+		}
+		write(nodeutil.ReflectChild(birds), m3, `{"names":["s1", "s2"]}`)
+		fc.AssertEqual(t, 2, len(birds.Names))
+		fc.AssertEqual(t, SpecialName("s1"), birds.Names[0])
+		fc.AssertEqual(t, SpecialName("s2"), birds.Names[1])
 	}
 	// structs
 	{


### PR DESCRIPTION
Using the conversion function of the go reflect API allows nodeutil.reflect to assign values derived from go basic types e.g.

`type MyString string`
