### PR TITLE
Improve list-format handling, especially for union-list subtypes

### DIFF
--- a/meta/compile.go
+++ b/meta/compile.go
@@ -295,7 +295,7 @@ func (c *compiler) compileType(y *Type, parent Leafable, isUnion bool) error {
 	}
 
 	if _, isList := parent.(*LeafList); isList && !y.format.IsList() {
-		y.format = val.Format(int(y.format) + 1024)
+		y.format = y.format.List()
 	}
 
 	if y.format == val.FmtUnion || y.format == val.FmtUnionList {

--- a/nodeutil/reflect.go
+++ b/nodeutil/reflect.go
@@ -207,6 +207,9 @@ func (self sliceSorter) findFunc(key []val.Value) func(int) bool {
 }
 
 func (self sliceSorter) find(key []val.Value) (node.Node, int) {
+	if len(self) == 0 {
+		return nil, -1
+	}
 	found := sort.Search(len(self), self.findFunc(key))
 	if found >= 0 && found < len(self) {
 		// Search find first match equal or greater, so we need to check for equality
@@ -429,6 +432,10 @@ func (self Reflect) create(t reflect.Type, m meta.Meta) reflect.Value {
 	switch t.Kind() {
 	case reflect.Ptr:
 		return reflect.New(t.Elem())
+	case reflect.Struct:
+		n := reflect.New(t)
+		e := n.Elem()
+		return e
 	case reflect.Interface:
 		switch x := m.(type) {
 		case *meta.List:

--- a/val/format.go
+++ b/val/format.go
@@ -2,6 +2,8 @@ package val
 
 type Format int
 
+const fmtListFlag Format = 1024
+
 // From RFC7950 Section 4.2.4 - Built-In Types
 
 const (
@@ -28,7 +30,7 @@ const (
 )
 
 const (
-	FmtBinaryList      Format = iota + 1025
+	FmtBinaryList      Format = iota + fmtListFlag + 1
 	FmtBitsList               //1026
 	FmtBoolList               //1027
 	FmtDecimal64List          //1028
@@ -74,11 +76,15 @@ var internalTypes = map[string]Format{
 }
 
 func (f Format) Single() Format {
-	return Format(f & 1023)
+	return f % fmtListFlag
+}
+
+func (f Format) List() Format {
+	return f | fmtListFlag
 }
 
 func (f Format) IsList() bool {
-	return f >= FmtBinaryList && f <= FmtAnyList
+	return f.List() == f
 }
 
 func (f Format) IsNumeric() bool {
@@ -98,7 +104,7 @@ func (f Format) String() string {
 		if f == candidate {
 			return name
 		}
-		if f-1024 == candidate {
+		if f == candidate.List() {
 			return name + "-list"
 		}
 	}


### PR DESCRIPTION
This PR cleans up the handling of the "list-variant" flag of the format type by replacing the magic number with an internal constant and adding another helper.

It also enforces that the union-types of a union-list are automatically converted to list-types.