### PR TITLE
Allow update a root node even if the strategy is insert

### DIFF
--- a/node/edit.go
+++ b/node/edit.go
@@ -179,9 +179,10 @@ func (e editor) node(from *Selection, to *Selection, m meta.HasDataDefinitions, 
 		defer toChild.Release()
 	}
 	toRequest.New = true
+
 	switch strategy {
 	case editInsert:
-		if toChild != nil {
+		if toChild != nil && from.Path.Len() > 1 {
 			return fmt.Errorf("%w. item '%s' found in '%s'.  ", fc.ConflictError, m.Ident(), fromRequest.Path)
 		}
 		if toChild, err = to.selekt(&toRequest); err != nil {


### PR DESCRIPTION
This PR is a bit more experimental, but it allows to do a PUT request directly on the root node instead of only on sub-containers/nodes.