### PR TITLE
Make sure that subtypes of unionlist are always converted into list

### DIFF
--- a/nodeutil/json_rdr_test.go
+++ b/nodeutil/json_rdr_test.go
@@ -87,6 +87,43 @@ func TestJsonRdrUnion(t *testing.T) {
 	}
 }
 
+func TestJsonRdrTypedefUnionList(t *testing.T) {
+	mstr := `
+    module x {
+        revision 0;
+        typedef ip-prefix {
+            type union {
+                type string;
+            }
+        }
+        leaf-list ip {
+            type ip-prefix;
+        }
+    }
+        `
+	m, err := parser.LoadModuleFromString(nil, mstr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{
+			in:  `{"ip":["10.0.0.1","10.0.0.2"]}`,
+			out: `{"ip":["10.0.0.1","10.0.0.2"]}`,
+		},
+	}
+	for _, json := range tests {
+		t.Log(json.in)
+		actual, err := WriteJSON(node.NewBrowser(m, ReadJSON(json.in)).Root())
+		if err != nil {
+			t.Error(err)
+		}
+		fc.AssertEqual(t, json.out, actual)
+	}
+}
+
 func TestNumberParse(t *testing.T) {
 	moduleStr := `
 module json-test {


### PR DESCRIPTION
UnionList subtypes formats must always be a list too. When using a typedef the format is initialized without the knowledge it will be later used in a leaflist, which leaves the format of the subtype a non-list one.