### PR TITLE
Copy union subtypes when mixing them in.

### DIFF
--- a/meta/core.go
+++ b/meta/core.go
@@ -822,7 +822,11 @@ func (base *Type) mixin(derived *Type) {
 		derived.base = base.base
 	}
 	if derived.unionTypes == nil {
-		derived.unionTypes = base.unionTypes
+		derived.unionTypes = make([]*Type, len(base.unionTypes))
+		for i := range base.unionTypes {
+			cpy := *base.unionTypes[i]
+			derived.unionTypes[i] = &cpy
+		}
 	}
 
 	// merge lengths

--- a/nodeutil/json_rdr_test.go
+++ b/nodeutil/json_rdr_test.go
@@ -124,6 +124,46 @@ func TestJsonRdrTypedefUnionList(t *testing.T) {
 	}
 }
 
+func TestJsonRdrTypedefMixedUnion(t *testing.T) {
+	mstr := `
+    module x {
+        revision 0;
+        typedef ip-prefix {
+            type union {
+                type string;
+            }
+        }
+        leaf-list ips {
+            type ip-prefix;
+        }
+		leaf ip {
+			type ip-prefix;
+		}
+    }
+        `
+	m, err := parser.LoadModuleFromString(nil, mstr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{
+			in:  `{"ips":["10.0.0.1","10.0.0.2"],"ip":"10.0.0.3"}`,
+			out: `{"ips":["10.0.0.1","10.0.0.2"],"ip":"10.0.0.3"}`,
+		},
+	}
+	for _, json := range tests {
+		t.Log(json.in)
+		actual, err := WriteJSON(node.NewBrowser(m, ReadJSON(json.in)).Root())
+		if err != nil {
+			t.Error(err)
+		}
+		fc.AssertEqual(t, json.out, actual)
+	}
+}
+
 func TestNumberParse(t *testing.T) {
 	moduleStr := `
 module json-test {

--- a/parser/testdata/types/gold/union.json
+++ b/parser/testdata/types/gold/union.json
@@ -49,10 +49,10 @@
                 {
                   "label":"b",
                   "id":1}],
-              "format":"enumList"},
+              "format":"enum"},
             {
               "ident":"int8",
-              "format":"int8List"}],
+              "format":"int8"}],
           "format":"union"}}},
     {
       "ident":"p",


### PR DESCRIPTION
Subtypes of unions are pointers. Copy the content of them in the mixin() function to prevent global redefinition to list types for named types.