### PR TITLE
add support for bitfields

### DIFF
--- a/node/value_test.go
+++ b/node/value_test.go
@@ -83,3 +83,37 @@ func TestToUnionList(t *testing.T) {
 	fc.AssertEqual(t, nil, err)
 	fc.AssertEqual(t, []string{"thirty-two", "thirty-three"}, v.Value())
 }
+
+func TestToBits(t *testing.T) {
+	b := &meta.Builder{}
+	m := b.Module("x", nil)
+	l := b.Leaf(m, "l")
+	dt := b.Type(l, "bits")
+	b0 := b.Bit(dt, "b0")
+	b.Position(b0, 0)
+	b1 := b.Bit(dt, "b1")
+	b.Position(b1, 1)
+	fc.RequireEqual(t, nil, meta.Compile(m))
+
+	// cast from int (empty)
+	v, err := NewValue(dt, 0)
+	fc.AssertEqual(t, nil, err)
+	fc.AssertEqual(t, uint64(0), v.Value())
+	fc.AssertEqual(t, "", v.String())
+
+	// cast from int (non empty)
+	v, err = NewValue(dt, 0b11)
+	fc.AssertEqual(t, uint64(0b11), v.Value())
+	fc.AssertEqual(t, "b0 b1", v.String())
+
+	// cast from string
+	v, err = NewValue(dt, "b1")
+	fc.AssertEqual(t, uint64(0b10), v.Value())
+	fc.AssertEqual(t, "b1", v.String())
+
+	// cast from []string (wrong order)
+	v, err = NewValue(dt, []string{"b1", "b0"})
+	fc.AssertEqual(t, uint64(0b11), v.Value())
+	// side effect: keeping order so input and output data are equal
+	fc.AssertEqual(t, "b1 b0", v.String())
+}

--- a/nodeutil/json_wtr.go
+++ b/nodeutil/json_wtr.go
@@ -284,7 +284,7 @@ func (wtr *JSONWtr) writeValue(p *node.Path, v val.Value) error {
 			if err := wtr.writeString(idtyStr); err != nil {
 				return err
 			}
-		case val.FmtString, val.FmtBinary:
+		case val.FmtString, val.FmtBinary, val.FmtBits:
 			if err := wtr.writeString(item.String()); err != nil {
 				return err
 			}

--- a/nodeutil/reflect.go
+++ b/nodeutil/reflect.go
@@ -544,12 +544,16 @@ func (self Reflect) WriteFieldWithFieldName(fieldName string, m meta.Leafable, p
 		switch fieldVal.Kind() {
 		case reflect.String:
 			fieldVal.SetString(e.Label)
+		default:
+			return fmt.Errorf("cannot convert identityref value to fieldvalue '%v'. Please use 'string' for identityref field definition", fieldVal.Kind())
 		}
 	case val.FmtIdentityRefList:
 		el := v.(val.IdentRefList)
 		switch fieldVal.Elem().Kind() {
 		case reflect.String:
 			fieldVal.Set(reflect.ValueOf(el.Labels()))
+		default:
+			return fmt.Errorf("cannot convert identityref value to fieldvalue '%v'. Please use 'string' for identityref field definition", fieldVal.Kind())
 		}
 	case val.FmtEnum:
 		e := v.(val.Enum)
@@ -558,6 +562,8 @@ func (self Reflect) WriteFieldWithFieldName(fieldName string, m meta.Leafable, p
 			fieldVal.SetInt(int64(e.Id))
 		case reflect.String:
 			fieldVal.SetString(e.Label)
+		default:
+			return fmt.Errorf("cannot convert enum value to fieldvalue '%v'. Please use 'int' or 'string' for enum field definition", fieldVal.Kind())
 		}
 	case val.FmtEnumList:
 		el := v.(val.EnumList)
@@ -566,6 +572,21 @@ func (self Reflect) WriteFieldWithFieldName(fieldName string, m meta.Leafable, p
 			fieldVal.Set(reflect.ValueOf(el.Ids()))
 		case reflect.String:
 			fieldVal.Set(reflect.ValueOf(el.Labels()))
+		default:
+			return fmt.Errorf("cannot convert enum value to fieldvalue '%v'. Please use 'int' or 'string' for enum field definition", fieldVal.Kind())
+		}
+	case val.FmtBits:
+		b := v.(val.Bits)
+		switch fieldVal.Kind() {
+		case reflect.Slice:
+			if fieldVal.Type().Elem().Kind() != reflect.String {
+				return fmt.Errorf("cannot assign bits value to type %T, only '[]string' or 'int' are accepted for bits representation", fieldVal.Interface())
+			}
+			fieldVal.Set(reflect.ValueOf(b.StringList))
+		case reflect.Int:
+			fieldVal.SetInt(int64(b.Decimal))
+		default:
+			return fmt.Errorf("cannot convert bits value to fieldvalue '%v'. Please use 'int' or '[]string' for bits field definition", fieldVal.Kind())
 		}
 	default:
 		value := reflect.ValueOf(v.Value())

--- a/val/types.go
+++ b/val/types.go
@@ -865,18 +865,21 @@ func (NotEmptyType) Value() interface{} {
 
 //////////////////////////
 
-type Bits []byte
+type Bits struct {
+	Decimal    uint64
+	StringList []string
+}
 
 func (Bits) Format() Format {
-	return FmtEmpty
+	return FmtBits
 }
 
 func (b Bits) String() string {
-	return string(b)
+	return strings.Join(b.StringList, " ")
 }
 
 func (b Bits) Value() interface{} {
-	return []byte(b)
+	return b.Decimal
 }
 
 type BitsList [][]byte


### PR DESCRIPTION
Here some next improvements from me :)
 - added support for bitfields. In golang can be stored as int or as []string to improve readability.
 - also added some error handling in types conversion
 
 Please, check if it's OK. Probably point me what tests I have to extend to cover that changes if needed.
 Thanks