### PR TITLE
call OnEndEdit always(!) if OnBeginEdit called successfully

### DIFF
--- a/node/selection.go
+++ b/node/selection.go
@@ -379,6 +379,11 @@ func (sel *Selection) Delete() (err error) {
 	if err := sel.beginEdit(NodeRequest{Source: sel, Delete: true, EditRoot: true}, true); err != nil {
 		return err
 	}
+	defer func() {
+		if endErr := sel.endEdit(NodeRequest{Source: sel, Delete: true, EditRoot: true}, true); endErr != nil {
+			err = fmt.Errorf("error during endEdit: %v, previous error: %w", endErr, err)
+		}
+	}()
 
 	if sel.InsideList {
 		r := ListRequest{
@@ -403,10 +408,6 @@ func (sel *Selection) Delete() (err error) {
 		if _, err := r.Selection.Node.Child(r); err != nil {
 			return err
 		}
-	}
-
-	if err := sel.endEdit(NodeRequest{Source: sel, Delete: true, EditRoot: true}, true); err != nil {
-		return err
 	}
 	return
 }

--- a/node/value_test.go
+++ b/node/value_test.go
@@ -98,22 +98,22 @@ func TestToBits(t *testing.T) {
 	// cast from int (empty)
 	v, err := NewValue(dt, 0)
 	fc.AssertEqual(t, nil, err)
-	fc.AssertEqual(t, uint64(0), v.Value())
+	fc.AssertEqual(t, []string(nil), v.Value())
 	fc.AssertEqual(t, "", v.String())
 
 	// cast from int (non empty)
 	v, err = NewValue(dt, 0b11)
-	fc.AssertEqual(t, uint64(0b11), v.Value())
+	fc.AssertEqual(t, []string{"b0", "b1"}, v.Value())
 	fc.AssertEqual(t, "b0 b1", v.String())
 
 	// cast from string
 	v, err = NewValue(dt, "b1")
-	fc.AssertEqual(t, uint64(0b10), v.Value())
+	fc.AssertEqual(t, []string{"b1"}, v.Value())
 	fc.AssertEqual(t, "b1", v.String())
 
 	// cast from []string (wrong order)
 	v, err = NewValue(dt, []string{"b1", "b0"})
-	fc.AssertEqual(t, uint64(0b11), v.Value())
+	fc.AssertEqual(t, []string{"b1", "b0"}, v.Value())
 	// side effect: keeping order so input and output data are equal
 	fc.AssertEqual(t, "b1 b0", v.String())
 }

--- a/val/types.go
+++ b/val/types.go
@@ -879,7 +879,7 @@ func (b Bits) String() string {
 }
 
 func (b Bits) Value() interface{} {
-	return b.Decimal
+	return b.StringList
 }
 
 type BitsList [][]byte


### PR DESCRIPTION
This one is tricky. I need to hold mutex during changes and it is not possible if `OnEndEdit` is not called in case of some error. This PR ensures that `OnEndEdit` is being called each time `OnBeginEdit` is called and succeeds.

First, please do a detailed review of test, I'm not sure that this is the best way to test this functionality (test fails on unchanged `edit.go` but generously, it looks ugly).
Second, please advice if there's another way of propagating changes back and forth from yang expected to be used instead of passing pointer to state?