### PR TITLE
call OnEndEdit always(!) if OnBeginEdit called successfully

### DIFF
--- a/node/edit_test.go
+++ b/node/edit_test.go
@@ -530,3 +530,44 @@ func testDataRoot() map[string]interface{} {
 		},
 	}
 }
+
+func TestNodeEndEditOnFailure(t *testing.T) {
+	mstr := `module m { prefix ""; namespace ""; revision 0;
+		container c {
+			leaf x {
+				type string;
+			}
+		}
+	}`
+	json, _ := nodeutil.ReadJSON(`{"x":4}`)
+	m, err := parser.LoadModuleFromString(nil, mstr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := &nodeutil.Basic{}
+	n.OnChild = func(r node.ChildRequest) (node.Node, error) {
+		return n, nil
+	}
+	var actual bytes.Buffer
+	n.OnBeginEdit = func(r node.NodeRequest) error {
+		fmt.Fprintf(&actual, "begin %s\n", r.Selection.Meta().Ident())
+		return nil
+	}
+	n.OnEndEdit = func(r node.NodeRequest) error {
+		fmt.Fprintf(&actual, "end %s\n", r.Selection.Meta().Ident())
+		return nil
+	}
+	root := node.NewBrowser(m, n).Root()
+	sel, err := root.Find("c")
+	fc.RequireEqual(t, nil, err)
+	err = sel.UpdateFrom(json)
+	if err == nil {
+		t.Error("Expected sel.UpdateFrom() to fail due to wrong argument")
+	}
+
+	fc.AssertEqual(t, `begin c
+begin m
+end c
+end m
+`, actual.String())
+}

--- a/node/selection.go
+++ b/node/selection.go
@@ -379,6 +379,11 @@ func (sel *Selection) Delete() (err error) {
 	if err := sel.beginEdit(NodeRequest{Source: sel, Delete: true, EditRoot: true}, true); err != nil {
 		return err
 	}
+	defer func() {
+		if endErr := sel.endEdit(NodeRequest{Source: sel, Delete: true, EditRoot: true}, true); endErr != nil {
+			err = fmt.Errorf("error during endEdit: %v, previous error: %w", endErr, err)
+		}
+	}()
 
 	if sel.InsideList {
 		r := ListRequest{
@@ -403,10 +408,6 @@ func (sel *Selection) Delete() (err error) {
 		if _, err := r.Selection.Node.Child(r); err != nil {
 			return err
 		}
-	}
-
-	if err := sel.endEdit(NodeRequest{Source: sel, Delete: true, EditRoot: true}, true); err != nil {
-		return err
 	}
 	return
 }


### PR DESCRIPTION
Rearranged branches a little. Original description:

This one is tricky. I need to hold mutex during changes and it is not possible if OnEndEdit is not called in case of some error. This PR ensures that OnEndEdit is being called each time OnBeginEdit is called and succeeds.

First, please do a detailed review of test, I'm not sure that this is the best way to test this functionality (test fails on unchanged edit.go but generously, it looks ugly).
Second, please advice if there's another way of propagating changes back and forth from yang expected to be used instead of passing pointer to state?
