### PR TITLE
fix: extract node type safely when calling OnRead handler

### DIFF
--- a/nodeutil/node.go
+++ b/nodeutil/node.go
@@ -407,7 +407,11 @@ func (ref *Node) readValue(m meta.Definition) (reflect.Value, error) {
 		return empty, err
 	}
 	if ref.OnRead != nil {
-		return ref.OnRead(ref, m, v.Type(), v)
+		t, err := c.getType(m)
+		if err != nil {
+			return v, err
+		}
+		return ref.OnRead(ref, m, t, v)
 	}
 	return v, nil
 }

--- a/nodeutil/node_test.go
+++ b/nodeutil/node_test.go
@@ -85,13 +85,9 @@ func TestReflectOnReadNilValue(t *testing.T) {
 	app := &reflectTestApp{
 		C: nil,
 	}
-
 	n := &Node{
 		Object: app,
 		OnRead: func(ref *Node, m meta.Definition, t reflect.Type, v reflect.Value) (reflect.Value, error) {
-			if t.Kind() == reflect.String {
-				return reflect.ValueOf(strings.ToUpper(v.String())), nil
-			}
 			return v, nil
 		},
 	}
@@ -99,7 +95,7 @@ func TestReflectOnReadNilValue(t *testing.T) {
 
 	defer func() {
 		if r := recover(); r != nil {
-			t.Errorf("The code panics! %v", r)
+			t.Errorf("The code panics: %v", r)
 		}
 	}()
 	WriteJSON(b.Root())

--- a/nodeutil/node_test.go
+++ b/nodeutil/node_test.go
@@ -98,7 +98,9 @@ func TestReflectOnReadNilValue(t *testing.T) {
 			t.Errorf("The code panics: %v", r)
 		}
 	}()
-	WriteJSON(b.Root())
+	actual, err := WriteJSON(b.Root())
+	fc.RequireEqual(t, nil, err)
+	fc.AssertEqual(t, "{}", actual)
 }
 
 func TestReflect(t *testing.T) {


### PR DESCRIPTION
Currently the OnRead handler panics when there is any 'nil' node in the tree.

Fix re-uses existing checks from OnWrite implementation and provides a repro unit test.