### PR TITLE
fix: panic when reading leaf inside empty list item

### DIFF
--- a/node/find.go
+++ b/node/find.go
@@ -91,7 +91,7 @@ func (sel *Selection) findSlice(segs []*Path) (*Selection, error) {
 				// not interested in key, should match seg[i].key in theory
 				var visible bool
 				p, visible, _, err = p.selectListItem(r)
-				if !visible || err != nil {
+				if !visible || p == nil || err != nil {
 					return nil, err
 				}
 			}

--- a/node/find_test.go
+++ b/node/find_test.go
@@ -173,6 +173,19 @@ func TestFindPathIntoListItemContainer(t *testing.T) {
 	}
 }
 
+func TestFindPathInsideEmptyList(t *testing.T) {
+	m, root := LoadPathTestData()
+	tests := []string{
+		"fruits=pear/origin/country",
+	}
+	for _, test := range tests {
+		root := node.NewBrowser(m, nodeutil.ReflectChild(root)).Root()
+		target, err := root.Find(test)
+		fc.RequireEqual(t, nil, err)
+		fc.AssertEqual(t, true, target == nil, "Target should not be found"+test)
+	}
+}
+
 func LoadPathTestData() (*meta.Module, map[string]interface{}) {
 	// avoid using json to load because that needs edit/INSERT and
 	// we don't want to use code to load seed data that we're trying to test

--- a/node/find_test.go
+++ b/node/find_test.go
@@ -166,8 +166,8 @@ func TestFindPathIntoListItemContainer(t *testing.T) {
 		"fruits=apple/boat",
 	}
 	for _, test := range tests {
-		root := node.NewBrowser(m, nodeutil.ReflectChild(root)).Root()
-		target, err := root.Find(test)
+		browser := node.NewBrowser(m, nodeutil.ReflectChild(root)).Root()
+		target, err := browser.Find(test)
 		fc.RequireEqual(t, nil, err)
 		fc.AssertEqual(t, true, target != nil, "Could not find target "+test)
 	}
@@ -175,15 +175,10 @@ func TestFindPathIntoListItemContainer(t *testing.T) {
 
 func TestFindPathInsideEmptyList(t *testing.T) {
 	m, root := LoadPathTestData()
-	tests := []string{
-		"fruits=pear/origin/country",
-	}
-	for _, test := range tests {
-		root := node.NewBrowser(m, nodeutil.ReflectChild(root)).Root()
-		target, err := root.Find(test)
-		fc.RequireEqual(t, nil, err)
-		fc.AssertEqual(t, true, target == nil, "Target should not be found"+test)
-	}
+	browser := node.NewBrowser(m, nodeutil.ReflectChild(root)).Root()
+	target, err := browser.Find("fruits=pear/origin/country")
+	fc.RequireEqual(t, nil, err)
+	fc.AssertEqual(t, true, target == nil, "Target should not be found (fruits=pear/origin/country)")
 }
 
 func LoadPathTestData() (*meta.Module, map[string]interface{}) {


### PR DESCRIPTION
Freeconf goroutine panics with 'runtime error: invalid memory address or nil pointer dereference' when a user tries to read a leaf or container from within a non-existing list item.