### PR TITLE
fix: fix error handling when inserting list item without key

### DIFF
--- a/node/path.go
+++ b/node/path.go
@@ -54,7 +54,11 @@ func (seg *Path) toBuffer(b *bytes.Buffer) {
 			if i != 0 {
 				b.WriteRune(',')
 			}
-			b.WriteString(k.String())
+			if k != nil {
+				b.WriteString(k.String())
+			} else {
+				b.WriteString("<nil>")
+			}
 		}
 	}
 }

--- a/nodeutil/node.go
+++ b/nodeutil/node.go
@@ -768,3 +768,15 @@ func (ndx *index) Swap(i, j int) {
 func (ndx *index) Less(i, j int) bool {
 	return ndx.comparator(ndx.vals[i], ndx.vals[j])
 }
+
+func isKeyValid(key []val.Value) bool {
+	if len(key) == 0 {
+		return false
+	}
+	for _, k := range key {
+		if k == nil {
+			return false
+		}
+	}
+	return true
+}

--- a/nodeutil/node_map.go
+++ b/nodeutil/node_map.go
@@ -66,7 +66,7 @@ func (def *mapAsList) setComparator(c ReflectListComparator) {
 
 func (def *mapAsList) getByKey(r node.ListRequest) (reflect.Value, error) {
 	var empty reflect.Value
-	if r.Key == nil || len(r.Key) == 0 {
+	if !isKeyValid(r.Key) {
 		return empty, fmt.Errorf("no key specified for %s", r.Path.String())
 	}
 	keyVal := reflect.ValueOf(r.Key[0].Value())
@@ -78,7 +78,7 @@ func (def *mapAsList) getByKey(r node.ListRequest) (reflect.Value, error) {
 }
 
 func (def *mapAsList) deleteByKey(r node.ListRequest) error {
-	if r.Key == nil || len(r.Key) == 0 {
+	if !isKeyValid(r.Key) {
 		return fmt.Errorf("no key specified for %s", r.Path.String())
 	}
 	keyVal := reflect.ValueOf(r.Key[0].Value())

--- a/nodeutil/node_slice.go
+++ b/nodeutil/node_slice.go
@@ -24,6 +24,9 @@ func newSliceAsList(ref *Node, src reflect.Value, u NodeListUpdate) *sliceAsList
 }
 
 func (def *sliceAsList) getByKey(r node.ListRequest) (reflect.Value, error) {
+	if !isKeyValid(r.Key) {
+		return reflect.Value{}, fmt.Errorf("invalid key for %v", r.Path.String())
+	}
 	row, v, err := def.findByKey(r.Meta, r.Key, r.Meta.KeyMeta())
 	if row < 0 || err != nil {
 		return v, err
@@ -105,6 +108,9 @@ func (def *sliceAsList) findByKey(m meta.Meta, target []val.Value, keyMeta []met
 }
 
 func (def *sliceAsList) deleteByKey(r node.ListRequest) error {
+	if !isKeyValid(r.Key) {
+		return fmt.Errorf("invalid key for %v", r.Path.String())
+	}
 	row, _, err := def.findByKey(r.Meta, r.Key, r.Meta.KeyMeta())
 	if row < 0 || err != nil {
 		return err


### PR DESCRIPTION
Encountered problem handling error when trying to add list item with erroneous key. 
Setup:
  - Yang:
```
module test-tree {
    yang-version 1.1;

    // namespace

    namespace urn:smth:yang:test-tree;
    prefix tt;

    organization
        "Test";
    contact
        "TBD";
    description
        "";
    reference
        "";

    // revisions

    revision 2023-11-21 {
        description
            "Initial version";
    }

    container testc {
        leaf testl {
            type boolean;
        }
        list testll {
            key k;
            leaf k {
                type int32;
            }
            leaf v {
                type string;
            }
        }
    }
}
```
  - Golang struct definition:
```
type root struct {
	Testc TestContainer
}

type ListItem struct {
	K int
	V string
}

type TestContainer struct {
	Testl  bool
	Testll []*ListItem
}
```

Running below cURL:
`curl -XPOST localhost/restconf/data/test-tree:testc/testll -d '{"testll": [{"d": 2, "v": "data"}]}'`
Panics:
```
2024/07/09 13:55:24 http: panic serving [::1]:52775: runtime error: invalid memory address or nil pointer dereference
goroutine 34 [running]:
net/http.(*conn).serve.func1()
	/opt/homebrew/Cellar/go/1.22.4/libexec/src/net/http/server.go:1898 +0xb0
panic({0x1048ab3c0?, 0x104bc5d10?})
	/opt/homebrew/Cellar/go/1.22.4/libexec/src/runtime/panic.go:770 +0x124
github.com/freeconf/yang/nodeutil.(*sliceAsList).findByKey(0x140000a0720, {0x10491ff30, 0x140001a6160}, {0x140000a23a0, 0x1, 0x1041edebc?}, {0x14000110430, 0x1, 0x1})
	/Users/manitou/dev/test/freeconf/yang/nodeutil/node_slice.go:97 +0x2f0
github.com/freeconf/yang/nodeutil.(*sliceAsList).getByKey(0x1041edf30?, {{0x140000b0370, 0x140000a0a50, 0x0, 0x140000a0810}, 0x140000b0410, 0x0, 0x0, 0x0, 0x0, ...})
	/Users/manitou/dev/test/freeconf/yang/nodeutil/node_slice.go:27 +0x40
github.com/freeconf/yang/nodeutil.(*Node).DoGetByKey(0x140000d6140, {{0x140000b0370, 0x140000a0a50, 0x0, 0x140000a0810}, 0x140000b0410, 0x0, 0x0, 0x0, 0x0, ...})
	/Users/manitou/dev/test/freeconf/yang/nodeutil/node.go:619 +0x58
github.com/freeconf/yang/nodeutil.(*Node).Next(0x0?, {{0x140000b0370, 0x140000a0a50, 0x0, 0x140000a0810}, 0x140000b0410, 0x0, 0x0, 0x0, 0x0, ...})
	/Users/manitou/dev/test/freeconf/yang/nodeutil/node.go:221 +0x1ac
github.com/freeconf/yang/nodeutil.dump.Node.func4({{0x140000b0370, 0x140000a0a50, 0x0, 0x140000a0810}, 0x140000b0410, 0x0, 0x0, 0x0, 0x0, 0x0, ...})
	/Users/manitou/dev/test/freeconf/yang/nodeutil/dump.go:136 +0x1ac
github.com/freeconf/yang/nodeutil.(*Basic).Next(0x104130d2c?, {{0x140000b0370, 0x140000a0a50, 0x0, 0x140000a0810}, 0x140000b0410, 0x0, 0x0, 0x0, 0x0, ...})
	/Users/manitou/dev/test/freeconf/yang/nodeutil/basic.go:172 +0x52c
github.com/freeconf/yang/node.(*Selection).selectListItem(0x140000b0370, 0x140000aa200)
```

This PR adds extra validation. To both cases, items list and items map. Please, review and merge if it is OK for you.
For me, not sure about 2 things here:
 - `r.Key == nil` seems like some legacy, because `r.Key` is a slice
 - did not find any tests to take as example to test this case
