### PR TITLE
refactor ReplaceFrom()

### DIFF
--- a/node/selection.go
+++ b/node/selection.go
@@ -385,6 +385,11 @@ func (sel *Selection) Delete() (err error) {
 		}
 	}()
 
+	err = sel.delete()
+	return
+}
+
+func (sel *Selection) delete() (err error) {
 	if sel.InsideList {
 		r := ListRequest{
 			Request: Request{
@@ -468,12 +473,10 @@ func (sel *Selection) UpdateInto(toNode Node) error {
 	return e.edit(sel, sel.Split(toNode), editUpdate)
 }
 
+// Replace current tree with given one
 func (sel *Selection) ReplaceFrom(fromNode Node) error {
-	parent := sel.parent
-	if err := sel.Delete(); err != nil {
-		return err
-	}
-	return parent.InsertFrom(fromNode)
+	e := editor{basePath: sel.Path}
+	return e.edit(sel.Split(fromNode), sel, editReplace)
 }
 
 // Copy given node into current node.  There must be matching containers of list

--- a/node/selection_test.go
+++ b/node/selection_test.go
@@ -84,7 +84,7 @@ func TestReplaceFrom(t *testing.T) {
 	sel, err := root.Find("bird=robin/species")
 	fc.RequireEqual(t, nil, err)
 	n, _ := nodeutil.ReadJSON(`
-		{"species":{"name":"dragon"}}
+		{"class":"dragon"}
 	`)
 	err = sel.ReplaceFrom(n)
 	fc.AssertEqual(t, nil, err)
@@ -92,17 +92,27 @@ func TestReplaceFrom(t *testing.T) {
 	fc.RequireEqual(t, nil, err)
 	actual, err := js.JSON(sel)
 	fc.AssertEqual(t, nil, err)
-	fc.AssertEqual(t, `{"name":"robin","wingspan":10,"species":{"name":"dragon"}}`, actual)
+	fc.AssertEqual(t, `{"name":"robin","wingspan":10,"species":{"class":"dragon"}}`, actual)
 
 	// list item
 	sel, err = root.Find("bird=robin")
 	fc.RequireEqual(t, nil, err)
 	n, _ = nodeutil.ReadJSON(`
-		{"bird":[{"name": "robin", "wingspan":11}]}
+		{"name": "robin", "wingspan":11}
 	`)
 	sel.ReplaceFrom(n)
 	fc.AssertEqual(t, nil, err)
 	actual, err = js.JSON(root)
 	fc.AssertEqual(t, nil, err)
 	fc.AssertEqual(t, `{"bird":[{"name":"blue jay","wingspan":0},{"name":"robin","wingspan":11}]}`, actual)
+
+	// whole list
+	n, _ = nodeutil.ReadJSON(`
+		{"bird":[{"name":"blue jay"},{"name":"malak","species":{"class":"jedi"}}]}
+	`)
+	root.ReplaceFrom(n)
+	fc.AssertEqual(t, nil, err)
+	actual, err = js.JSON(root)
+	fc.AssertEqual(t, nil, err)
+	fc.AssertEqual(t, `{"bird":[{"name":"blue jay","wingspan":0},{"name":"malak","wingspan":0,"species":{"class":"jedi"}}]}`, actual)
 }

--- a/nodeutil/reflect.go
+++ b/nodeutil/reflect.go
@@ -487,7 +487,11 @@ func (self Reflect) strukt(ptrVal reflect.Value) node.Node {
 		},
 		OnField: func(r node.FieldRequest, hnd *node.ValueHandle) (err error) {
 			if r.Write {
-				err = self.WriteField(r.Meta, ptrVal, hnd.Val)
+				if r.Clear {
+					elemVal.SetZero()
+				} else {
+					err = self.WriteField(r.Meta, ptrVal, hnd.Val)
+				}
 			} else {
 				hnd.Val, err = self.ReadField(r.Meta, ptrVal)
 			}


### PR DESCRIPTION
In relation to #100, prepared PR with refactor of `ReplaceFrom()` to enclose all changes in single BeginEdit-EndEdit frame to be able to enclose it with transaction.

Had to do small enhancements to `reflect.go` to be able to reuse existing `TestReplaceFrom()` test. Reflect-based Node did not tolerate request flags.
Also, please pay attention to changed payload structure in test, please ensure that such change is not breaking any existing contracts. I found several usecases where payload structure is not compatible with RESTCONF rfc8040 spec. I'll try to fix that in future PRs.
And finally, list cleanup code might be not optimal, but it is baseline for optimizations. Please, give feedback if you see a easy way to improve that.
Hope this PR is good enough for this project. I've put a lot of effort to understand this edit strategy but still intuition is a big part of this PR :)